### PR TITLE
feat(tlv): add tag-length-value io type

### DIFF
--- a/src/lib/index.mts
+++ b/src/lib/index.mts
@@ -1,6 +1,7 @@
 import ArrayIo from './type/ArrayIo.mjs';
 import StringIo from './type/StringIo.mjs';
 import StructIo from './type/StructIo.mjs';
+import TlvIo, { TlvValueCallback } from './type/TlvIo.mjs';
 import { getType } from './util.mjs';
 
 const array = (type, options) => new ArrayIo(type, options);
@@ -8,6 +9,12 @@ const array = (type, options) => new ArrayIo(type, options);
 const string = (options) => new StringIo(options);
 
 const struct = (fields, options) => new StructIo(fields, options);
+
+const tlv = (
+  tagType: IoType,
+  lengthType: IoType,
+  valueCallback: TlvValueCallback,
+) => new TlvIo(tagType, lengthType, valueCallback);
 
 const int8 = {
   read: (stream: Stream) => stream.readInt8(),
@@ -127,6 +134,7 @@ const io = {
   array,
   string,
   struct,
+  tlv,
   int8,
   uint8,
   int16,

--- a/src/lib/type/TlvIo.mts
+++ b/src/lib/type/TlvIo.mts
@@ -1,6 +1,9 @@
 import { Endianness, getStream } from '../util.mjs';
 
-type TlvValueCallback = (type: string | number, length: number) => IoType;
+type TlvValueCallback = (
+  type: string | number,
+  length: number,
+) => IoType | undefined | null;
 
 type TlvOptions = {
   endianness?: Endianness;
@@ -15,7 +18,7 @@ type Tlv = {
 /**
  * TlvIo provides an IoType for tag-length-value (sometimes called type-length-value) types. The tag can be any IoType
  * that resolves to a string or number. The length can be any IoType that resolves to a number. The value can be any
- * IoType.
+ * IoType, or a Uint8Array.
  */
 class TlvIo implements IoType {
   #tagType: IoType;
@@ -28,7 +31,8 @@ class TlvIo implements IoType {
    *
    * @param tagType - An IoType that resolves to a string or number.
    * @param lengthType - An IoType that resolves to a number.
-   * @param valueCallback - A function that returns any IoType from the given tag and length.
+   * @param valueCallback - A function that returns any IoType from the given tag and length. If the callback returns
+   *   undefined or null, the value will be read as a Uint8Array.
    * @param options
    */
   constructor(


### PR DESCRIPTION
This PR introduces a tag-length-value `IoType`, suitable for reading formats similar to IFF/RIFF (like `.wmo` files).