### PR TITLE
feat: permit getting size of io types

### DIFF
--- a/src/lib/index.mts
+++ b/src/lib/index.mts
@@ -17,115 +17,141 @@ const tlv = (
 ) => new TlvIo(tagType, lengthType, valueCallback);
 
 const int8 = {
+  getSize: (_value: number) => 1,
   read: (stream: Stream) => stream.readInt8(),
   write: (stream: Stream, value: number) => stream.writeInt8(value),
 };
 
 const uint8 = {
+  getSize: (_value: number) => 1,
   read: (stream: Stream) => stream.readUint8(),
   write: (stream: Stream, value: number) => stream.writeUint8(value),
 };
 
 const int16 = {
+  getSize: (_value: number) => 2,
   read: (stream: Stream) => stream.readInt16(),
   write: (stream: Stream, value: number) => stream.writeInt16(value),
 };
 const int16be = {
+  getSize: (_value: number) => 2,
   read: (stream: Stream) => stream.readInt16Be(),
   write: (stream: Stream, value: number) => stream.writeInt16Be(value),
 };
 const int16le = {
+  getSize: (_value: number) => 2,
   read: (stream: Stream) => stream.readInt16Le(),
   write: (stream: Stream, value: number) => stream.writeInt16Le(value),
 };
 
 const uint16 = {
+  getSize: (_value: number) => 2,
   read: (stream: Stream) => stream.readUint16(),
   write: (stream: Stream, value: number) => stream.writeUint16(value),
 };
 const uint16be = {
+  getSize: (_value: number) => 2,
   read: (stream: Stream) => stream.readUint16Be(),
   write: (stream: Stream, value: number) => stream.writeUint16Be(value),
 };
 const uint16le = {
+  getSize: (_value: number) => 2,
   read: (stream: Stream) => stream.readUint16Le(),
   write: (stream: Stream, value: number) => stream.writeUint16Le(value),
 };
 
 const int32 = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readInt32(),
   write: (stream: Stream, value: number) => stream.writeInt32(value),
 };
 const int32be = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readInt32Be(),
   write: (stream: Stream, value: number) => stream.writeInt32Be(value),
 };
 const int32le = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readInt32Le(),
   write: (stream: Stream, value: number) => stream.writeInt32Le(value),
 };
 
 const uint32 = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readUint32(),
   write: (stream: Stream, value: number) => stream.writeUint32(value),
 };
 const uint32be = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readUint32Be(),
   write: (stream: Stream, value: number) => stream.writeUint32Be(value),
 };
 const uint32le = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readUint32Le(),
   write: (stream: Stream, value: number) => stream.writeUint32Le(value),
 };
 
 const int64 = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readInt64(),
   write: (stream: Stream, value: bigint) => stream.writeInt64(value),
 };
 const int64be = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readInt64Be(),
   write: (stream: Stream, value: bigint) => stream.writeInt64Be(value),
 };
 const int64le = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readInt64Le(),
   write: (stream: Stream, value: bigint) => stream.writeInt64Le(value),
 };
 
 const uint64 = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readUint64(),
   write: (stream: Stream, value: bigint) => stream.writeUint64(value),
 };
 const uint64be = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readUint64Be(),
   write: (stream: Stream, value: bigint) => stream.writeUint64Be(value),
 };
 const uint64le = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readUint64Le(),
   write: (stream: Stream, value: bigint) => stream.writeUint64Le(value),
 };
 
 const float32 = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readFloat32(),
   write: (stream: Stream, value: number) => stream.writeFloat32(value),
 };
 const float32be = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readFloat32Be(),
   write: (stream: Stream, value: number) => stream.writeFloat32Be(value),
 };
 const float32le = {
+  getSize: (_value: number) => 4,
   read: (stream: Stream) => stream.readFloat32Le(),
   write: (stream: Stream, value: number) => stream.writeFloat32Le(value),
 };
 
 const float64 = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readFloat64(),
   write: (stream: Stream, value: number) => stream.writeFloat64(value),
 };
 const float64be = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readFloat64Be(),
   write: (stream: Stream, value: number) => stream.writeFloat64Be(value),
 };
 const float64le = {
+  getSize: (_value: number) => 8,
   read: (stream: Stream) => stream.readFloat64Le(),
   write: (stream: Stream, value: number) => stream.writeFloat64Le(value),
 };

--- a/src/lib/type/ArrayIo.mts
+++ b/src/lib/type/ArrayIo.mts
@@ -17,6 +17,16 @@ class ArrayIo implements IoType {
     this.#options = options;
   }
 
+  getSize(value: any[]) {
+    let size = 0;
+
+    for (const v of value) {
+      size += this.#type.getSize(v);
+    }
+
+    return size;
+  }
+
   read(source: Source, context: Context = {}) {
     const stream = getStream(source);
     const value = [];

--- a/src/lib/type/StringIo.mts
+++ b/src/lib/type/StringIo.mts
@@ -23,6 +23,11 @@ class StringIo implements IoType {
     this.#encoder = new TextEncoder();
   }
 
+  getSize(value: string) {
+    const encodedSize = this.#encoder.encode(value).byteLength;
+    return this.#terminate ? encodedSize + 1 : encodedSize;
+  }
+
   #readRawBytes(stream: Stream, size: number | undefined) {
     if (typeof size === 'number') {
       const untrimmedBytes = stream.readBytes(size);

--- a/src/lib/type/StructIo.mts
+++ b/src/lib/type/StructIo.mts
@@ -20,6 +20,16 @@ class StructIo implements IoType {
     );
   }
 
+  getSize(value: any) {
+    let size = 0;
+
+    for (const [name, type] of Object.entries(this.#fields)) {
+      size += getType(type).getSize(value[name]);
+    }
+
+    return size;
+  }
+
   read(source: Source, context: Context = {}) {
     const stream = getStream(source, this.#options.endianness);
     const value = {};

--- a/src/lib/type/TlvIo.mts
+++ b/src/lib/type/TlvIo.mts
@@ -47,6 +47,14 @@ class TlvIo implements IoType {
     this.#options = options;
   }
 
+  getSize(value: Tlv) {
+    const tagSize = this.#tagType.getSize(value.tag);
+    const lengthSize = this.#lengthType.getSize(value.length);
+    const valueSize = value.length;
+
+    return tagSize + lengthSize + valueSize;
+  }
+
   read(source: Source, context: Context = {}): Tlv {
     const stream = getStream(source, this.#options.endianness);
 

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -4,6 +4,7 @@ type Context = {
 };
 
 type IoType = {
+  getSize: (value: any) => number;
   read: (source: Source, context: Context) => any;
   write?: (source: Source, value: any, context: Context) => any;
 };


### PR DESCRIPTION
To simplify writing `IoType`s to fixed length streams (eg. `ArrayBufferStream`), this PR adds a `getSize` function to the `IoType` interface.