### PR TITLE
fix(tlv): handle underruns and overruns during writes

### DIFF
--- a/src/lib/type/TlvIo.mts
+++ b/src/lib/type/TlvIo.mts
@@ -87,13 +87,20 @@ class TlvIo implements IoType {
     context.root = context.root ?? null;
 
     this.#tagType.write(stream, value.tag, context);
+
     this.#lengthType.write(stream, value.length, context);
+    const expectedEndOffset = stream.offset + value.length;
 
     const valueType = this.#valueCallback(value.tag, value.length);
     if (valueType && valueType.write) {
       valueType.write(stream, value.value, context);
     } else {
       stream.writeBytes(value.value);
+    }
+
+    // Account for underruns and overruns
+    if (stream.offset !== expectedEndOffset) {
+      stream.offset = expectedEndOffset;
     }
   }
 }


### PR DESCRIPTION
This PR adjusts the writing logic for `TlvIo` to account for cases where `value` writes are shorter than the specified `length`. Useful for situations in which the value being written is incomplete.