### PR TITLE
chore: refactor getType into validateType

### DIFF
--- a/src/lib/index.mts
+++ b/src/lib/index.mts
@@ -2,9 +2,9 @@ import ArrayIo, { ArrayOptions } from './type/ArrayIo.mjs';
 import StringIo, { StringOptions } from './type/StringIo.mjs';
 import StructIo, { StructFields, StructOptions } from './type/StructIo.mjs';
 import TlvIo, { TlvValueCallback } from './type/TlvIo.mjs';
-import { getType } from './util.mjs';
+import { validateType } from './util.mjs';
 
-const array = (type: Function | IoType, options: ArrayOptions) =>
+const array = (type: IoType, options: ArrayOptions) =>
   new ArrayIo(type, options);
 
 const string = (options: StringOptions) => new StringIo(options);
@@ -189,7 +189,7 @@ const io = {
   float64,
   float64be,
   float64le,
-  getType,
+  validateType,
 };
 
 export default io;

--- a/src/lib/type/ArrayIo.mts
+++ b/src/lib/type/ArrayIo.mts
@@ -1,4 +1,4 @@
-import { getStream, getType } from '../util.mjs';
+import { getStream, validateType } from '../util.mjs';
 
 type ArrayOptions = {
   size?: number;
@@ -8,12 +8,14 @@ class ArrayIo implements IoType {
   #type: IoType;
   #options: ArrayOptions;
 
-  constructor(type: Function | IoType, options: ArrayOptions = {}) {
+  constructor(type: IoType, options: ArrayOptions = {}) {
     if (type === undefined) {
       throw new Error('Missing required argument: type');
     }
 
-    this.#type = getType(type);
+    validateType(type);
+
+    this.#type = type;
     this.#options = options;
   }
 

--- a/src/lib/type/StructIo.mts
+++ b/src/lib/type/StructIo.mts
@@ -1,6 +1,6 @@
-import { Endianness, getStream, getType } from '../util.mjs';
+import { Endianness, getStream, validateType } from '../util.mjs';
 
-type StructFields = Record<string, Function | IoType>;
+type StructFields = Record<string, IoType>;
 
 type StructOptions = {
   endianness?: Endianness;
@@ -12,6 +12,11 @@ class StructIo implements IoType {
 
   constructor(fields: StructFields = {}, options: StructOptions = {}) {
     this.#fields = fields;
+
+    for (const type of Object.values(fields)) {
+      validateType(type);
+    }
+
     this.#options = options;
   }
 
@@ -30,7 +35,7 @@ class StructIo implements IoType {
     let size = 0;
 
     for (const [name, type] of Object.entries(this.#fields)) {
-      size += getType(type).getSize(value[name]);
+      size += type.getSize(value[name]);
     }
 
     return size;
@@ -44,7 +49,7 @@ class StructIo implements IoType {
     context.root = context.root ?? value;
 
     for (const [name, type] of Object.entries(this.#fields)) {
-      value[name] = getType(type).read(stream, context);
+      value[name] = type.read(stream, context);
     }
 
     return value;
@@ -57,7 +62,7 @@ class StructIo implements IoType {
     context.root = context.root ?? value;
 
     for (const [name, type] of Object.entries(this.#fields)) {
-      getType(type).write(stream, value[name], context);
+      type.write(stream, value[name], context);
     }
   }
 }

--- a/src/lib/util.mts
+++ b/src/lib/util.mts
@@ -8,14 +8,14 @@ enum Endianness {
 const getStream = (source: Source, endianness = Endianness.Little): Stream =>
   isStream(source) ? (source as Stream) : openStream(source, endianness);
 
-const getType = (type: Function | IoType): IoType => {
-  const resolvedType = typeof type === 'function' ? type() : type;
-
-  if (typeof resolvedType.read !== 'function') {
-    throw new Error('Missing required function: read');
+const validateType = (type: IoType) => {
+  if (typeof type.getSize !== 'function') {
+    throw new Error('Missing required function: getSize');
   }
 
-  return resolvedType;
+  if (typeof type.read !== 'function') {
+    throw new Error('Missing required function: read');
+  }
 };
 
 const resolveValue = (ref: number | string, ...objects: object[]) => {
@@ -31,4 +31,4 @@ const resolveValue = (ref: number | string, ...objects: object[]) => {
   }
 };
 
-export { Endianness, getStream, getType, resolveValue };
+export { Endianness, getStream, validateType, resolveValue };


### PR DESCRIPTION
This PR refactors `getType` into `validateType` by removing function support for type arguments and adding a check for `getSize` as a required function for types.