### PR TITLE
chore: collapse getStream into openStream

### DIFF
--- a/src/lib/stream/util.mts
+++ b/src/lib/stream/util.mts
@@ -16,7 +16,9 @@ const openStream = (
   source: IoSource,
   endianness = Endianness.Little,
 ): IoStream => {
-  if (typeof source === 'string' || typeof source === 'number') {
+  if (isStream(source)) {
+    return source as IoStream;
+  } else if (typeof source === 'string' || typeof source === 'number') {
     return new FsStream(source, endianness);
   } else if (ArrayBuffer.isView(source)) {
     return new ArrayBufferStream(

--- a/src/lib/type/ArrayIo.mts
+++ b/src/lib/type/ArrayIo.mts
@@ -1,4 +1,5 @@
-import { getStream, validateType } from '../util.mjs';
+import { validateType } from '../util.mjs';
+import { openStream } from '../stream/util.mjs';
 
 type ArrayOptions = {
   size?: number;
@@ -30,7 +31,7 @@ class ArrayIo implements IoType {
   }
 
   read(source: IoSource, context: IoContext = {}) {
-    const stream = getStream(source);
+    const stream = openStream(source);
     const value = [];
     const size = this.#options.size;
 
@@ -51,7 +52,7 @@ class ArrayIo implements IoType {
   }
 
   write(source: IoSource, value: any[], context: IoContext = {}) {
-    const stream = getStream(source);
+    const stream = openStream(source);
     const size = value.length;
     const type = this.#type;
 

--- a/src/lib/type/StringIo.mts
+++ b/src/lib/type/StringIo.mts
@@ -1,4 +1,5 @@
-import { getStream, resolveValue } from '../util.mjs';
+import { resolveValue } from '../util.mjs';
+import { openStream } from '../stream/util.mjs';
 
 const STRING_TERMINATOR = 0x00;
 const DEFAULT_ENCODING = 'utf-8';
@@ -47,7 +48,7 @@ class StringIo implements IoType {
   }
 
   read(source: IoSource, context: IoContext = {}) {
-    const stream = getStream(source);
+    const stream = openStream(source);
     const size = resolveValue(this.#options.size, context.local, context.root);
 
     const rawBytes = this.#readRawBytes(stream, size);
@@ -57,7 +58,7 @@ class StringIo implements IoType {
   }
 
   write(source: IoSource, value: string, context: IoContext = {}) {
-    const stream = getStream(source);
+    const stream = openStream(source);
 
     const finalValue = this.#options.reverse
       ? value.split('').reverse().join('')

--- a/src/lib/type/StructIo.mts
+++ b/src/lib/type/StructIo.mts
@@ -1,4 +1,5 @@
-import { Endianness, getStream, validateType } from '../util.mjs';
+import { Endianness, validateType } from '../util.mjs';
+import { openStream } from '../stream/util.mjs';
 
 type StructFields = Record<string, IoType>;
 
@@ -42,7 +43,7 @@ class StructIo implements IoType {
   }
 
   read(source: IoSource, context: IoContext = {}) {
-    const stream = getStream(source, this.#options.endianness);
+    const stream = openStream(source, this.#options.endianness);
     const value = {};
 
     context.local = value;
@@ -56,7 +57,7 @@ class StructIo implements IoType {
   }
 
   write(source: IoSource, value: object, context: IoContext = {}) {
-    const stream = getStream(source, this.#options.endianness);
+    const stream = openStream(source, this.#options.endianness);
 
     context.local = value;
     context.root = context.root ?? value;

--- a/src/lib/type/TlvIo.mts
+++ b/src/lib/type/TlvIo.mts
@@ -1,4 +1,5 @@
-import { Endianness, getStream } from '../util.mjs';
+import { Endianness } from '../util.mjs';
+import { openStream } from '../stream/util.mjs';
 
 type TlvValueCallback = (
   type: string | number,
@@ -56,7 +57,7 @@ class TlvIo implements IoType {
   }
 
   read(source: IoSource, context: IoContext = {}): Tlv {
-    const stream = getStream(source, this.#options.endianness);
+    const stream = openStream(source, this.#options.endianness);
 
     context.local = null;
     context.root = context.root ?? null;
@@ -69,7 +70,7 @@ class TlvIo implements IoType {
 
     let valueValue = valueBytes;
     if (valueType && valueType.read) {
-      const valueStream = getStream(valueBytes, this.#options.endianness);
+      const valueStream = openStream(valueBytes, this.#options.endianness);
       valueValue = valueType.read(valueStream, context);
     }
 
@@ -81,7 +82,7 @@ class TlvIo implements IoType {
   }
 
   write(source: IoSource, value: Tlv, context: IoContext = {}) {
-    const stream = getStream(source, this.#options.endianness);
+    const stream = openStream(source, this.#options.endianness);
 
     context.local = null;
     context.root = context.root ?? null;

--- a/src/lib/util.mts
+++ b/src/lib/util.mts
@@ -1,15 +1,7 @@
-import { isStream, openStream } from './stream/util.mjs';
-
 enum Endianness {
   Little = 1,
   Big = 2,
 }
-
-const getStream = (
-  source: IoSource,
-  endianness = Endianness.Little,
-): IoStream =>
-  isStream(source) ? (source as IoStream) : openStream(source, endianness);
 
 const validateType = (type: IoType) => {
   if (typeof type.getSize !== 'function') {
@@ -34,4 +26,4 @@ const resolveValue = (ref: number | string, ...objects: object[]) => {
   }
 };
 
-export { Endianness, getStream, validateType, resolveValue };
+export { Endianness, validateType, resolveValue };

--- a/src/spec/util.spec.mts
+++ b/src/spec/util.spec.mts
@@ -1,23 +1,23 @@
 import { describe, expect, test } from 'vitest';
-import { getStream } from '../lib/util.mts';
 import FsStream from '../lib/stream/FsStream.mts';
 import ArrayBufferStream from '../lib/stream/ArrayBufferStream.mts';
+import { openStream } from '../lib/stream/util.mjs';
 
 describe('getStream', () => {
   test('returns FsStream object when given path to file', () => {
-    const stream = getStream('./fixture/fixture.bmp');
+    const stream = openStream('./fixture/fixture.bmp');
     expect(stream).toBeInstanceOf(FsStream);
   });
 
   test('returns ArrayBufferStream object when given Uint8Array', () => {
     const view = new Uint8Array(10);
-    const stream = getStream(view);
+    const stream = openStream(view);
     expect(stream).toBeInstanceOf(ArrayBufferStream);
   });
 
   test('returns ArrayBufferStream object when given ArrayBuffer', () => {
     const buffer = new ArrayBuffer(10);
-    const stream = getStream(buffer);
+    const stream = openStream(buffer);
     expect(stream).toBeInstanceOf(ArrayBufferStream);
   });
 });


### PR DESCRIPTION
Since `openStream` already largely handles different types of `IoSource`, there isn't much reason to keep `getStream` separate.