### PR TITLE
feat(stream): add export for openStream helper

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -3,6 +3,7 @@ import StringIo, { StringOptions } from './type/StringIo.js';
 import StructIo, { StructFields, StructOptions } from './type/StructIo.js';
 import TlvIo, { TlvValueCallback } from './type/TlvIo.js';
 import { validateType } from './util.js';
+import { openStream } from './stream/util.js';
 
 const array = (type: IoType, options: ArrayOptions) =>
   new ArrayIo(type, options);
@@ -189,5 +190,6 @@ export {
   float64,
   float64be,
   float64le,
+  openStream,
   validateType,
 };


### PR DESCRIPTION
This PR adds an export for the `openStream` helper. We can reasonably expect consumers of `@wowserhq/io` will be interested in creating streams outside of the behavior of the built-in `IoType`s.