### PR TITLE
fix(types): ensure common types are visible in published package

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,7 @@ import StructIo, { StructFields, StructOptions } from './type/StructIo.js';
 import TlvIo, { TlvValueCallback } from './type/TlvIo.js';
 import { validateType } from './util.js';
 import { openStream } from './stream/util.js';
+import { IoStream, IoType } from './types.js';
 
 const array = (type: IoType, options: ArrayOptions) =>
   new ArrayIo(type, options);

--- a/src/lib/stream/ArrayBufferStream.ts
+++ b/src/lib/stream/ArrayBufferStream.ts
@@ -1,4 +1,5 @@
 import { Endianness } from '../util.js';
+import { IoStream } from '../types.js';
 
 class ArrayBufferStream implements IoStream {
   #buffer: ArrayBuffer;

--- a/src/lib/stream/FsStream.ts
+++ b/src/lib/stream/FsStream.ts
@@ -1,5 +1,6 @@
 import fs from '../shim/fs.cjs';
 import { Endianness } from '../util.js';
+import { IoStream } from '../types.js';
 
 class FsStream implements IoStream {
   #fd: number;

--- a/src/lib/stream/util.ts
+++ b/src/lib/stream/util.ts
@@ -1,6 +1,7 @@
 import ArrayBufferStream from './ArrayBufferStream.js';
 import FsStream from './FsStream.js';
 import { Endianness } from '../util.js';
+import { IoSource, IoStream } from '../types.js';
 
 const isStream = (ref: any) => {
   if (ref instanceof ArrayBufferStream) {

--- a/src/lib/type/ArrayIo.ts
+++ b/src/lib/type/ArrayIo.ts
@@ -1,5 +1,6 @@
 import { validateType } from '../util.js';
 import { openStream } from '../stream/util.js';
+import { IoContext, IoSource, IoType } from '../types.js';
 
 type ArrayOptions = {
   size?: number;

--- a/src/lib/type/StringIo.ts
+++ b/src/lib/type/StringIo.ts
@@ -1,5 +1,6 @@
 import { resolveValue } from '../util.js';
 import { openStream } from '../stream/util.js';
+import { IoContext, IoSource, IoStream, IoType } from '../types.js';
 
 const STRING_TERMINATOR = 0x00;
 const DEFAULT_ENCODING = 'utf-8';

--- a/src/lib/type/StructIo.ts
+++ b/src/lib/type/StructIo.ts
@@ -1,5 +1,6 @@
 import { Endianness, validateType } from '../util.js';
 import { openStream } from '../stream/util.js';
+import { IoContext, IoSource, IoType } from '../types.js';
 
 type StructFields = Record<string, IoType>;
 

--- a/src/lib/type/TlvIo.ts
+++ b/src/lib/type/TlvIo.ts
@@ -1,5 +1,6 @@
 import { Endianness } from '../util.js';
 import { openStream } from '../stream/util.js';
+import { IoContext, IoSource, IoType } from '../types.js';
 
 type TlvValueCallback = (
   type: string | number,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,3 +74,5 @@ type IoType = {
   read: (source: IoSource, context: IoContext) => any;
   write?: (source: IoSource, value: any, context: IoContext) => any;
 };
+
+export { IoContext, IoSource, IoStream, IoType };

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,3 +1,5 @@
+import { IoType } from './types.js';
+
 enum Endianness {
   Little = 1,
   Big = 2,


### PR DESCRIPTION
This PR corrects an oversight that led to common types like `IoStream` and `IoType` being excluded from the published `@wowserhq/io` package.