### PR TITLE
feat: make options optional for array, string, and struct helpers

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,12 +6,12 @@ import { validateType } from './util.js';
 import { openStream } from './stream/util.js';
 import { IoContext, IoSource, IoStream, IoType } from './types.js';
 
-const array = (type: IoType, options: ArrayOptions) =>
+const array = (type: IoType, options: ArrayOptions = {}) =>
   new ArrayIo(type, options);
 
-const string = (options: StringOptions) => new StringIo(options);
+const string = (options: StringOptions = {}) => new StringIo(options);
 
-const struct = (fields: StructFields, options: StructOptions) =>
+const struct = (fields: StructFields, options: StructOptions = {}) =>
   new StructIo(fields, options);
 
 const tlv = (


### PR DESCRIPTION
Since each of `ArrayIo`, `StringIo`, and `StructIo` provides sensible defaults for options, we can make options default to empty object in the `array`, `string`, and `struct` helper functions.