### PR TITLE
feat: make context optional in IoType read

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,7 +71,7 @@ type IoStream = {
 
 type IoType = {
   getSize: (value: any) => number;
-  read: (source: IoSource, context: IoContext) => any;
+  read: (source: IoSource, context?: IoContext) => any;
   write?: (source: IoSource, value: any, context: IoContext) => any;
 };
 


### PR DESCRIPTION
Since `context`'s properties (`local` and `root`) are given values if not already defined, `context` can be marked as optional for `IoType`'s `read` signature.